### PR TITLE
Represent time (currentTime, timeLeft, totalTime) in milliseconds instead of Date objects.

### DIFF
--- a/app/scripts/com/2fdevs/videogular/plugins/controls.js
+++ b/app/scripts/com/2fdevs/videogular/plugins/controls.js
@@ -173,19 +173,17 @@ angular.module("com.2fdevs.videogular.plugins.controls", [])
 			require: "^videogular",
 			restrict: "E",
 			link: function (scope, elem, attr, API) {
-        scope.currentTime = API.currentTime;
-        scope.timeLeft = API.timeLeft;
-        scope.totalTime = API.totalTime;
-        scope.isLive = API.isLive;
+				scope.currentTime = API.currentTime;
+				scope.timeLeft = API.timeLeft;
+				scope.totalTime = API.totalTime;
+				scope.isLive = API.isLive;
 
 				scope.$watch(
 					function () {
 						return API.currentTime;
 					},
 					function (newVal, oldVal) {
-						if (newVal != oldVal) {
-							scope.currentTime = newVal;
-						}
+						scope.currentTime = newVal;
 					}
 				);
 
@@ -194,9 +192,7 @@ angular.module("com.2fdevs.videogular.plugins.controls", [])
 						return API.timeLeft;
 					},
 					function (newVal, oldVal) {
-						if (newVal != oldVal) {
-							scope.timeLeft = newVal;
-						}
+						scope.timeLeft = newVal;
 					}
 				);
 
@@ -205,9 +201,7 @@ angular.module("com.2fdevs.videogular.plugins.controls", [])
 						return API.totalTime;
 					},
 					function (newVal, oldVal) {
-						if (newVal != oldVal) {
-							scope.totalTime = newVal;
-						}
+						scope.totalTime = newVal;
 					}
 				);
 
@@ -216,9 +210,7 @@ angular.module("com.2fdevs.videogular.plugins.controls", [])
 						return API.isLive;
 					},
 					function (newVal, oldVal) {
-						if (newVal != oldVal) {
-							scope.isLive = newVal;
-						}
+						scope.isLive = newVal;
 					}
 				);
 			}
@@ -266,7 +258,7 @@ angular.module("com.2fdevs.videogular.plugins.controls", [])
 
 				scope.API = API;
 				scope.ariaTime = function(time) {
-					return (time === 0) ? "0" : Math.round(time.getTime() / 1000);
+					return Math.round(time / 1000);
 				};
 
 				function onScrubBarTouchStart($event) {
@@ -361,9 +353,7 @@ angular.module("com.2fdevs.videogular.plugins.controls", [])
 				}
 
 				scope.onScrubBarKeyDown = function(event) {
-          var currentISO = API.currentTime.getTime() - (API.totalTime.getTimezoneOffset() * 60000);
-          var totalISO = API.totalTime.getTime() - (API.totalTime.getTimezoneOffset() * 60000);
-					var currentPercent = currentISO / totalISO * 100;
+					var currentPercent = (API.currentTime / API.totalTime) * 100;
 
 					if (event.which === LEFT || event.keyCode === LEFT) {
 						API.seekTime(currentPercent - NUM_PERCENT, true);
@@ -455,18 +445,16 @@ angular.module("com.2fdevs.videogular.plugins.controls", [])
 				var percentTime = 0;
 
 				function onUpdateTime(newCurrentTime) {
-					if (newCurrentTime && API.totalTime) {
-            var currentISO = newCurrentTime.getTime() - (API.totalTime.getTimezoneOffset() * 60000);
-            var totalISO = API.totalTime.getTime() - (API.totalTime.getTimezoneOffset() * 60000);
-						percentTime = (currentISO * -1 / 1000) * 100 / (totalISO * -1 / 1000);
+					if (typeof newCurrentTime === 'number' && API.totalTime) {
+						percentTime = 100 * (newCurrentTime / API.totalTime);
 						elem.css("width", percentTime + "%");
+					} else {
+						elem.css("width", 0);
 					}
 				}
 
-				function onComplete() {
-					percentTime = 0;
-					elem.css("width", percentTime + "%");
-				}
+				// Initial call to set vg-scrubbarcurrenttime
+				onUpdateTime(percentTime);
 
 				scope.$watch(
 					function () {
@@ -474,15 +462,6 @@ angular.module("com.2fdevs.videogular.plugins.controls", [])
 					},
 					function (newVal, oldVal) {
 						onUpdateTime(newVal);
-					}
-				);
-
-				scope.$watch(
-					function () {
-						return API.isCompleted;
-					},
-					function (newVal, oldVal) {
-						onComplete(newVal);
 					}
 				);
 			}

--- a/app/scripts/com/2fdevs/videogular/videogular.js
+++ b/app/scripts/com/2fdevs/videogular/videogular.js
@@ -54,21 +54,6 @@ angular.module("com.2fdevs.videogular", ["ngSanitize"])
       return zIndex;
     };
 
-    this.toUTCDate = function(date){
-      return new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), date.getUTCHours(), date.getUTCMinutes(), date.getUTCSeconds(), date.getUTCMilliseconds());
-    };
-
-    this.secondsToDate = function (seconds) {
-      if (isNaN(seconds)) seconds = 0;
-
-      var result = new Date();
-      result.setTime(seconds * 1000);
-
-      result = this.toUTCDate(result);
-
-      return result;
-    };
-
     // Very simple mobile detection, not 100% reliable
     this.isMobileDevice = function () {
       return (typeof window.orientation !== "undefined") || (navigator.userAgent.indexOf("IEMobile") !== -1);
@@ -243,11 +228,11 @@ angular.module("com.2fdevs.videogular", ["ngSanitize"])
         };
 
         this.onUpdateTime = function (event) {
-          $scope.API.currentTime = VG_UTILS.secondsToDate(event.target.currentTime);
+          $scope.API.currentTime = 1000 * event.target.currentTime;
 
           if (event.target.duration != Infinity) {
-            $scope.API.totalTime = VG_UTILS.secondsToDate(event.target.duration);
-            $scope.API.timeLeft = VG_UTILS.secondsToDate(event.target.duration - event.target.currentTime);
+            $scope.API.totalTime = 1000 * event.target.duration;
+            $scope.API.timeLeft = 1000 * (event.target.duration - event.target.currentTime);
             $scope.API.isLive = false;
           }
           else {
@@ -289,7 +274,7 @@ angular.module("com.2fdevs.videogular", ["ngSanitize"])
             $scope.API.mediaElement[0].currentTime = second;
           }
 
-          $scope.API.currentTime = VG_UTILS.secondsToDate(second);
+          $scope.API.currentTime = 1000 * second;
         };
 
         this.playPause = function () {
@@ -463,9 +448,9 @@ angular.module("com.2fdevs.videogular", ["ngSanitize"])
         $scope.init = function () {
           $scope.API.isReady = false;
           $scope.API.isCompleted = false;
-          $scope.API.currentTime = VG_UTILS.secondsToDate(0);
-          $scope.API.totalTime = VG_UTILS.secondsToDate(0);
-          $scope.API.timeLeft = VG_UTILS.secondsToDate(0);
+          $scope.API.currentTime = 0;
+          $scope.API.totalTime = 0;
+          $scope.API.timeLeft = 0;
           $scope.API.isLive = false;
 
           $scope.API.updateTheme($scope.theme);


### PR DESCRIPTION
**BREAKING CHANGE**

Represent time (`currentTime`, `timeLeft`, `totalTime`) in milliseconds instead of Date objects. When I started using videogular I wondered why videogular uses `Date` objects for the representation of various times. Milliseconds are easier to calculate with and do not have the complexities of working with time zones. [jPlayer](https://github.com/happyworm/jPlayer), a major video player for jQuery, also does all its time-related calculations in seconds, and I see no reason why videogular should not do the same.

In the videogular-controls plugin, the `currentTime`, `timeLeft` and `totalTime` variables are exposed to the UI. For this, the AngularJS [date filter](https://docs.angularjs.org/api/ng/filter/date) is used. This remains unchanged after this PR, since the AngularJS [date filter](https://docs.angularjs.org/api/ng/filter/date) accepts both `Date` objects as well as milliseconds. From its docs on the `date` argument:

> Date to format either as Date object, milliseconds (string or number) or various ISO 8601 datetime string formats (e.g. yyyy-MM-ddTHH:mm:ss.sssZ and its shorter versions like yyyy-MM-ddTHH:mmZ, yyyy-MM-dd or yyyyMMddTHHmmssZ).

When using custom filters (I am looking into creating a filter to display the current frame number of a video) calculating with milliseconds is easier than parsing the Date object and keeping in mind the time zones. Not only filters, but all computations using `currentTime`, `timeLeft` and `totalTime`, benefit from this. For example soton-ecs-2014-gdp-12/videogular-cuepoints/issues/3

Furthermore, this PR also fixes the (previously incorrect) values in the aria-value* attributes. In the demo on http://www.videogular.com 

```html
<div ng-keydown="onScrubBarKeyDown($event)" ng-transclude="" tabindex="0" aria-label="Time scrub bar" aria-valuemin="0" aria-valuenow="-3586" aria-valuemax="-3502" role="slider">
	<vg-scrubbarcurrenttime class="ng-scope" style="width: 14.1379%;"></vg-scrubbarcurrenttime>
</div>
```

As you can see, the `aria-valuenow` and `aria-valuemax` are negative numbers.

Other minor changes:
- Fix indent in controls.js. Tabs and spaces were used at different places.
- Simplify watches on scope variables related to times from the API. I have removed some `if (newVal != oldVal)` checks. From the [AngularJS docs on scope](https://docs.angularjs.org/api/ng/type/$rootScope.Scope): 

> The listener is called only when the value from the current watchExpression and the previous call to watchExpression are not equal (with the exception of the initial run, see below).

- On video complete, scrubbar remains at 100%. This is in line with the `currentTime`, which also remains at 100% on video complete.