### PR TITLE
vgChangeSource callback triggers when the video player begins a new file

### DIFF
--- a/app/scripts/com/2fdevs/videogular/directives/vg-media.js
+++ b/app/scripts/com/2fdevs/videogular/directives/vg-media.js
@@ -3,9 +3,9 @@
  * @name com.2fdevs.videogular.direcitve:vgMedia
  * @restrict E
  * @description
- * Directive to add a source of videos or audios. This directive will create a &lt;video&gt; tag and usually will be above plugin tags.
+ * Directive to add a source of videos or audios. This directive will create a &lt;video&gt; or &lt;audio&gt; tag and usually will be above plugin tags.
  *
- * @param {array} vgSrc Bindable array with a list of media sources. A media source is an object with two properties `src` and `type`. The `src` property must contains a trusful url resource.
+ * @param {array} vgSrc Bindable array with a list of media sources. A media source is an object with two properties `src` and `type`. The `src` property must contains a trustful url resource.
  * @param {string} vgType String with "video" or "audio" values to set a <video> or <audio> tag inside <vg-media>.
  * <pre>
  * {
@@ -66,6 +66,8 @@ angular.module("com.2fdevs.videogular")
               if (canPlay == "maybe" || canPlay == "probably") {
                 API.mediaElement.attr("src", sources[i].src);
                 API.mediaElement.attr("type", sources[i].type);
+                //Trigger vgChangeSource($source) API callback in vgController
+                API.changeSource(sources[i]);
                 break;
               }
             }
@@ -75,6 +77,8 @@ angular.module("com.2fdevs.videogular")
             // Get H264 or the first one
             API.mediaElement.attr("src", sources[0].src);
             API.mediaElement.attr("type", sources[0].type);
+            //Trigger vgChangeSource($source) API callback in vgController
+            API.changeSource(sources[0]);
           }
 
           // Android 2.3 support: https://github.com/2fdevs/videogular/issues/187


### PR DESCRIPTION
Hello Videogular!

I had difficulties when trying to use the Videogular API callback: `vgChangeSource()`. 
[The API ](http://www.videogular.com/tutorials/videogular-api/) lists this callback as ```vgChangeSource($source): Called when __volume__ has been changed. Returns the new media source.```
And [the docs](http://www.videogular.com/docs/#/api/com.2fdevs.videogular.directive:videogular) list the callback as: ```Function name in controller's scope to change current video source. Receives a param with the new video.```

With this edit, my wrapper directive controller can now bind to `vgChangeSource` and be notified whenever the video element begins playing a new source. 

Use case
* server has a video file stored at several resolutions and bitrate qualities
* users must be able to select a higher or lower quality video file from the player.
* If video was in progress, resume new quality video at same 'currentTime' location.

Approach
* store video time index and playback state when user selects a different video quality
* when new file is loaded, seekTime to stored location and resume previous playback state

Problem
* ambiguous detection for: 'when new file is loaded...'.

Workaround
It seems `onUpdateTime()` is called with either (0,NaN) or (0,metadata.duration) when the source file is changed, and logic can trigger off that, but from the API descriptions, using `vgChangeSource($source)` sounded like the correct way to be notified when the video file changed.

-------

Please let me know If I am misunderstanding the API callback intention, or if I can provide any more feedback to make this pull request more clear.

Thank you for the work you have done in making this library; it is truly a fantastic video player framework.
