### PR TITLE
New features: Persistent volume and vgCanPlay callback

### DIFF
--- a/app/scripts/com/2fdevs/videogular/constants/vg-constants.js
+++ b/app/scripts/com/2fdevs/videogular/constants/vg-constants.js
@@ -8,10 +8,17 @@
  *  - VG_STATES.PAUSE: "pause"
  *  - VG_STATES.STOP: "stop"
  **/
+/**
+ * @ngdoc service
+ * @name com.2fdevs.videogular.constant:VG_VOLUME_LOCAL_STORAGE
+ *
+ * @description localStorage key for storing volume changes.
+ **/
 "use strict";
 angular.module("com.2fdevs.videogular")
   .constant("VG_STATES", {
     PLAY: "play",
     PAUSE: "pause",
     STOP: "stop"
-  });
+  })
+  .constant("VG_VOLUME_KEY", "videogularVolume");

--- a/app/scripts/com/2fdevs/videogular/constants/vg-constants.js
+++ b/app/scripts/com/2fdevs/videogular/constants/vg-constants.js
@@ -10,9 +10,9 @@
  **/
 /**
  * @ngdoc service
- * @name com.2fdevs.videogular.constant:VG_VOLUME_LOCAL_STORAGE
+ * @name com.2fdevs.videogular.constant:VG_VOLUME_KEY
  *
- * @description localStorage key for storing volume changes.
+ * @description localStorage key name for persistent video play volume on a domain.
  **/
 "use strict";
 angular.module("com.2fdevs.videogular")

--- a/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
+++ b/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
@@ -88,6 +88,12 @@ angular.module("com.2fdevs.videogular")
 
             isMetaDataLoaded = true;
 
+            //Set media volume from localStorage if available
+            if (VG_UTILS.supportsLocalStorage()) {
+                //Default to 100% volume if local storage setting does not exist.
+                this.setVolume(parseFloat($window.localStorage.getItem(VG_VOLUME_KEY) || '1'));
+            }
+
             if ($scope.vgConfig) {
                 vgConfigLoader.loadConfig($scope.vgConfig).then(
                     this.onLoadConfig.bind(this)
@@ -97,21 +103,6 @@ angular.module("com.2fdevs.videogular")
                 $scope.vgPlayerReady({$API: this});
             }
         };
-      //Set media volume from localStorage if available
-      if (VG_UTILS.supportsLocalStorage()) {
-        //Default to 100% volume if local storage setting does not exist.
-        this.setVolume(parseFloat($window.localStorage.getItem(VG_VOLUME_KEY) || '1'));
-      }
-
-      if ($scope.vgConfig) {
-        vgConfigLoader.loadConfig($scope.vgConfig).then(
-          this.onLoadConfig.bind(this)
-        );
-      }
-      else {
-        $scope.vgPlayerReady({$API: this});
-      }
-    };
 
         this.onLoadConfig = function (config) {
             this.config = config;

--- a/app/scripts/com/2fdevs/videogular/directives/videogular.js
+++ b/app/scripts/com/2fdevs/videogular/directives/videogular.js
@@ -85,6 +85,7 @@
   }
 }
  * </pre>
+ * @param {function} vgCanPlay Function name in controller's scope to call when video is able to begin playback
  * @param {function} vgComplete Function name in controller's scope to call when video have been completed.
  * @param {function} vgUpdateVolume Function name in controller's scope to call when volume changes. Receives a param with the new volume.
  * @param {function} vgUpdateTime Function name in controller's scope to call when video playback time is updated. Receives two params with current time and duration in milliseconds.
@@ -109,6 +110,7 @@ angular.module("com.2fdevs.videogular")
         vgPlaysInline: "=?",
         vgCuePoints: "=?",
         vgConfig: "@",
+        vgCanPlay: "&",
         vgComplete: "&",
         vgUpdateVolume: "&",
         vgUpdateTime: "&",

--- a/app/scripts/com/2fdevs/videogular/plugins/vg-controls/vg-volume/vg-mute-button.js
+++ b/app/scripts/com/2fdevs/videogular/plugins/vg-controls/vg-volume/vg-mute-button.js
@@ -84,7 +84,6 @@ angular.module("com.2fdevs.videogular.plugins.controls")
           scope.onSetVolume = function onSetVolume(newVolume) {
             scope.currentVolume = newVolume;
 
-            // TODO: Save volume with LocalStorage
             // if it's not muted we save the default volume
             if (!isMuted) {
               scope.defaultVolume = newVolume;
@@ -118,8 +117,8 @@ angular.module("com.2fdevs.videogular.plugins.controls")
           scope.currentVolume = scope.defaultVolume;
           scope.muteIcon = {level3: true};
 
-          //TODO: get volume from localStorage
-
+          //Update the mute button on initialization, then watch for changes
+          scope.onSetVolume(API.volume);
           scope.$watch(
             function () {
               return API.volume;

--- a/app/scripts/com/2fdevs/videogular/plugins/vg-controls/vg-volume/vg-volume-bar.js
+++ b/app/scripts/com/2fdevs/videogular/plugins/vg-controls/vg-volume/vg-volume-bar.js
@@ -91,6 +91,8 @@ angular.module("com.2fdevs.videogular.plugins.controls")
 
           scope.$watch("volumeVisibility", scope.onChangeVisibility);
 
+          //Update the volume bar on initialization, then watch for changes
+          scope.updateVolumeView(API.volume);
           scope.$watch(
             function () {
               return API.volume;

--- a/app/scripts/com/2fdevs/videogular/services/vg-utils.js
+++ b/app/scripts/com/2fdevs/videogular/services/vg-utils.js
@@ -1,6 +1,6 @@
 "use strict";
 angular.module("com.2fdevs.videogular")
-  .service("VG_UTILS", function () {
+  .service("VG_UTILS", ["$window", function ($window) {
     this.fixEventOffset = function ($event) {
       /**
        * There's no offsetX in Firefox, so we fix that.
@@ -51,4 +51,16 @@ angular.module("com.2fdevs.videogular")
     this.isiOSDevice = function () {
       return (navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i) || navigator.userAgent.match(/iPad/i));
     };
-  });
+
+    /**
+     * Test the browser's support for HTML5 localStorage.
+     * @returns {boolean}
+     */
+    this.supportsLocalStorage = function() {
+      try {
+        return 'localStorage' in $window && $window['localStorage'] !== null;
+      } catch (e) {
+        return false;
+      }
+    };
+  }]);

--- a/test/spec/plugins/vg-controls.js
+++ b/test/spec/plugins/vg-controls.js
@@ -7,7 +7,9 @@ describe('Directive: Controls', function () {
 	var $compile;
 	var $timeout;
 	var VG_STATES;
+    var VG_VOLUME_KEY;
 	var VG_UTILS;
+    var $window;
 
 	beforeEach(module('com.2fdevs.videogular'));
 	beforeEach(module('com.2fdevs.videogular.plugins.controls'));
@@ -18,7 +20,11 @@ describe('Directive: Controls', function () {
     $sce = $injector.get('$sce');
     $timeout = $injector.get('$timeout');
     VG_STATES = $injector.get('VG_STATES');
+    VG_VOLUME_KEY = $injector.get('VG_VOLUME_KEY');
     VG_UTILS = $injector.get('VG_UTILS');
+    $window = $injector.get('$window');
+
+    $window.localStorage.clear(); //Forget about localStorage volume between tests
 
     $scope.config = {
       preload: "none",
@@ -379,6 +385,11 @@ describe('Directive: Controls', function () {
 
       // Is NaN because there's no height
       expect(API.setVolume).toHaveBeenCalledWith(NaN);
+    });
+    it("should write volume settings to localStorage", function() {
+      API.setVolume(0.5);
+      $scope.$digest();
+      expect(window.localStorage[VG_VOLUME_KEY]).toBe("0.5");
     });
   });
 });


### PR DESCRIPTION
This PR is the result of a series of emails with Elecash discussing my application's needs, but the changes are intended for flexibility and customization for developers.

New features:
* Volume changes are saved to localStorage under the key 'videogularVolume'
* media volume is set from localStorage's value on initialization (if available) otherwise defaults to 100% as it always has.
* vgMuteButton and vgVolumeBar will load with the correct values if volume is not 100%.
* new callback: vgCanPlay($event). Forwards the media elements 'canplay' events to the developer. Videogular was already internally using this event. Now, the event is also bindable for external use.

After feedback from @Elecash, I changed sessionStorage to localStorage. This allows the volume setting to persist after window closing on a single domain.

Tests are currently passing on:
(Windows 7)
Firefox 36.0.0
Chrome 41.0.2272
