### PR TITLE
Quick fix for Firefox 39 (Dev edition) which have offset

### DIFF
--- a/app/scripts/com/2fdevs/videogular/services/vg-utils.js
+++ b/app/scripts/com/2fdevs/videogular/services/vg-utils.js
@@ -9,7 +9,8 @@ angular.module("com.2fdevs.videogular")
              * @param $event
              * @returns {*}
              */
-            if (navigator.userAgent.match(/Firefox/i)) {
+            var matchedFF = navigator.userAgent.match(/Firefox\/(\d+)/i)
+            if (matchedFF && Number.parseInt(matchedFF.pop()) < 39) {
                 var style = $event.currentTarget.currentStyle || window.getComputedStyle($event.target, null);
                 var borderLeftWidth = parseInt(style['borderLeftWidth'], 10);
                 var borderTopWidth = parseInt(style['borderTopWidth'], 10);


### PR DESCRIPTION
Hello, Videogular doesn't work on Firefox Developer Edition (39.0a2 currently).
I've done a quick fix for that. Maybe you have a more beautiful fix to replace this one, but the idea is here.

Regards & and thanks for the job,
Nainterceptor