### PR TITLE
This ensures that the controls playPauseButton and overlay play are in play state when vg-auto-play is true

### DIFF
--- a/app/scripts/com/2fdevs/videogular/plugins/vg-controls/vg-play-pause-button/vg-play-pause-button.js
+++ b/app/scripts/com/2fdevs/videogular/plugins/vg-controls/vg-play-pause-button/vg-play-pause-button.js
@@ -60,9 +60,7 @@ angular.module("com.2fdevs.videogular.plugins.controls")
                         return API.currentState;
                     },
                     function (newVal, oldVal) {
-                        if (newVal != oldVal) {
-                            scope.setState(newVal);
-                        }
+                        scope.setState(newVal);
                     }
                 );
             }

--- a/app/scripts/com/2fdevs/videogular/plugins/vg-overlay-play/vg-overlay-play.js
+++ b/app/scripts/com/2fdevs/videogular/plugins/vg-overlay-play/vg-overlay-play.js
@@ -67,9 +67,7 @@ angular.module("com.2fdevs.videogular.plugins.overlayplay", [])
                         return API.currentState;
                     },
                     function (newVal, oldVal) {
-                        if (newVal != oldVal) {
-                            scope.onChangeState(newVal);
-                        }
+                        scope.onChangeState(newVal);
                     }
                 );
             }


### PR DESCRIPTION
This closes #40 .

always set player state rather than when the newVal != oldVal

Test results are the same as before making changes:
```
Firefox 35.0.0 (Mac OS X 10.10): Executed 53 of 55 (skipped 2) SUCCESS (2.853 secs / 3.347 secs)
```

```
Chrome 42.0.2311 (Mac OS X 10.10.3) LOG: 'Failed loading manifest: source.mpd, retry in 500ms attempts: 3'
Chrome 42.0.2311 (Mac OS X 10.10.3) LOG: 'Failed loading manifest: source.mpd, retry in 500ms attempts: 3'
Chrome 42.0.2311 (Mac OS X 10.10.3): Executed 53 of 55 (skipped 2) SUCCESS (4.114 secs / 4.013 secs)
TOTAL: 106 SUCCESS
```