### PR TITLE
Fixes error caused by Safari private browsing mode

### DIFF
--- a/app/scripts/com/2fdevs/videogular/services/vg-utils.js
+++ b/app/scripts/com/2fdevs/videogular/services/vg-utils.js
@@ -61,7 +61,12 @@ angular.module("com.2fdevs.videogular")
          * @returns {boolean}
          */
         this.supportsLocalStorage = function () {
+            var testKey = 'videogular-test-key';
+            var storage = $window.sessionStorage;
+
             try {
+                storage.setItem(testKey, '1');
+                storage.removeItem(testKey);
                 return 'localStorage' in $window && $window['localStorage'] !== null;
             } catch (e) {
                 return false;


### PR DESCRIPTION
Safari private browsing mode disables local storage, which causes an error to be thrown when the setVolume method is called. This change amends the supportsLocalStorage utility method to return false when local storage is available but disabled, such as in the case of Safari private browsing.

Issue: https://github.com/2fdevs/videogular/issues/237