### PR TITLE
fix regression on 1.2.4 - scope.vgSrc can't be defined after videogular

### DIFF
--- a/app/scripts/com/2fdevs/videogular/directives/vg-media.js
+++ b/app/scripts/com/2fdevs/videogular/directives/vg-media.js
@@ -102,17 +102,13 @@ angular.module("com.2fdevs.videogular")
                 API.addListeners();
                 API.onVideoReady();
 
-                if (scope.vgSrc) {
-                    scope.$watch("vgSrc", scope.onChangeSource);
-                }
-                else {
+					scope.$watch("vgSrc", scope.onChangeSource);
                     scope.$watch(
                       function() {
                           return API.sources;
                       },
                       scope.onChangeSource
                     );
-                }
 
                 if (API.isConfig) {
                     scope.$watch(


### PR DESCRIPTION
Watch both vgSrc and API
Regression on 1.2.4 scope.vgSrc doesn't support to be defined after videogular, the if statement is executed only once