### PR TITLE
[vg-dash] Fix source change from DASH to non-DASH

### DIFF
--- a/app/scripts/com/2fdevs/videogular/plugins/vg-dash/vg-dash.js
+++ b/app/scripts/com/2fdevs/videogular/plugins/vg-dash/vg-dash.js
@@ -28,30 +28,28 @@ angular.module("com.2fdevs.videogular.plugins.dash", [])
             restrict: "A",
             require: "^videogular",
             link: function (scope, elem, attr, API) {
-                var context;
                 var player;
 
                 scope.isDASH = function isDASH(url) {
-                    if (url.indexOf) {
-                        return (url.indexOf(".mpd") > 0);
-                    }
+                    return url.indexOf && (url.indexOf(".mpd") > 0);
                 };
 
                 scope.onSourceChange = function onSourceChange(url) {
                     // It's DASH, we use Dash.js
                     if (scope.isDASH(url)) {
-                        context = new Dash.di.DashContext();
-                        player = new MediaPlayer(context);
+                        player = new MediaPlayer(new Dash.di.DashContext());
                         player.setAutoPlay(API.autoPlay);
                         player.startup();
                         player.attachView(API.mediaElement[0]);
                         player.attachSource(url);
                     }
-                    else {
-                        if (player) {
-                            player.reset();
-                            player = null;
-                        }
+                    else if (player) {//not DASH, but the Dash.js player is still wired up
+                        //Dettach Dash.js from the mediaElement
+                        player.reset();
+                        player = null;
+
+                        //player.reset() wipes out the new url already applied, so have to reapply
+                        API.mediaElement.attr('src', url);
                     }
                 };
 


### PR DESCRIPTION
Fix issue #248 for the vg-dash plugin. It was not able to successfully handle switching of the media source from DASH to non-DASH. Seems to be a sequencing issue where the new src would be applied to the video element prior to detaching Dash.js. The Dash.js reset() would then wipe out the src. Now reapply it to the mediaElement after reset().

Also did some very minor clean up and commenting. The context variable did not need to be shared as it's used only to initialize the Dash.js MediaPlayer. It's the player that exposes the useful public API.